### PR TITLE
Characters of attribute contain `@` and `.`.

### DIFF
--- a/plugin/textobj/xmlattr.vim
+++ b/plugin/textobj/xmlattr.vim
@@ -8,7 +8,7 @@ endif
 " A word: `attr=value`, with no quotes.
 let s:RE_WORD = '\(\w\+\)'
 " An attribute name: `src`, `data-attr`, `strange_attr`.
-let s:RE_ATTR_NAME = '\([a-zA-Z0-9\-_:]\+\)'
+let s:RE_ATTR_NAME = '\([a-zA-Z0-9\-_:@.]\+\)'
 " A quoted string.
 let s:RE_QUOTED_STR = '\(".\{-}"\)'
 " The value of an attribute: a word with no quotes or a quoted string.


### PR DESCRIPTION
Hi.

I use Vue.js. https://github.com/vuejs/vue
Vue.js use `@` and `.` as attribute. Please see an example http://vuejs.org/api/#v-on .


So, I'm happy if this PR is merged. 
However, XML doesn't allow `@` in an attribute.... http://www.w3.org/TR/REC-xml/#NT-Attribute


What do you think?


--------

example

```html
<button @click="doThis"></button>
<button @click.prevent="doThis"></button>
```