### PR TITLE
Use "depends on" syntax for `vim-plug` instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ appealing!).
 
 ``` viml
 " vim-plug
-Plug 'kana/vim-textobj-user'
-Plug 'whatyouhide/vim-textobj-xmlattr'
+Plug 'kana/vim-textobj-user' | Plug 'whatyouhide/vim-textobj-xmlattr'
 " NeoBundle
 NeoBundle 'kana/vim-textobj-user'
 NeoBundle 'whatyouhide/vim-textobj-xmlattr'


### PR DESCRIPTION
Just a small refactor for the `.vimrc` configuration file when using `vim-plug`.
